### PR TITLE
#25-Filtered and paginated sightings backend

### DIFF
--- a/api/Controllers/SightingController.cs
+++ b/api/Controllers/SightingController.cs
@@ -34,9 +34,9 @@ public class SightingController : ControllerBase
 
     // GET: api/Sightings
     [HttpGet("")]
-    public ActionResult<IEnumerable<Sighting>> GetAllSightings([FromQuery] SightingsQueryParameters parameters)
+    public ActionResult<IEnumerable<Sighting>> GetSightingsBySearchQuery([FromQuery] SightingsQueryParameters parameters)
     {
-        var sightings = _sightingRepository.GetAllSightings(parameters);
+        var sightings = _sightingRepository.GetSightingsBySearchQuery(parameters);
         if (sightings == null)
         {
             return NotFound();

--- a/api/Controllers/SightingController.cs
+++ b/api/Controllers/SightingController.cs
@@ -34,9 +34,9 @@ public class SightingController : ControllerBase
 
     // GET: api/Sightings
     [HttpGet("")]
-    public ActionResult<IEnumerable<Sighting>> GetAllSightings()
+    public ActionResult<IEnumerable<Sighting>> GetAllSightings([FromQuery] SightingsQueryParameters parameters)
     {
-        var sightings = _sightingRepository.GetAllSightings();
+        var sightings = _sightingRepository.GetAllSightings(parameters);
         if (sightings == null)
         {
             return NotFound();

--- a/api/Database/WhaleSpottingDbContext.cs
+++ b/api/Database/WhaleSpottingDbContext.cs
@@ -78,7 +78,8 @@ public class WhaleSpottingDbContext : IdentityDbContext<User>
         List<Sighting> sightings = [];
         for (int i = 0; i < 20; i++)
         {
-            sightings.Add(new Sighting(){
+            sightings.Add(new Sighting()
+            {
                 Id = i + 1,
                 SpeciesId = (i % 10) + 1,
                 Description = $"Details of Sighting {i + 1}",

--- a/api/Models/ApiModels/CreateSightingRequest.cs
+++ b/api/Models/ApiModels/CreateSightingRequest.cs
@@ -7,5 +7,5 @@ public class CreateSightingRequest
     public required int Quantity { get; set; }
     public required double Latitude { get; set; }
     public required double Longitude { get; set; }
-    public required string ImageSource { get; set; }
+    public string? ImageSource { get; set; }
 }

--- a/api/Models/ApiModels/SightingsQueryParameters.cs
+++ b/api/Models/ApiModels/SightingsQueryParameters.cs
@@ -9,7 +9,7 @@ public class SightingsQueryParameters
         get
         { return _pageSize; }
         set
-        { _pageSize = value < 50 ? _pageSize = value : _pageSize = _maxPageSize; }
+        { _pageSize = value < _maxPageSize ? _pageSize = value : _pageSize = _maxPageSize; }
     }
     private readonly int _maxPageSize = 50;
     public int? SpeciesId { get; set; }

--- a/api/Models/ApiModels/SightingsQueryParameters.cs
+++ b/api/Models/ApiModels/SightingsQueryParameters.cs
@@ -3,8 +3,16 @@ namespace WhaleSpottingBackend.Models.ApiModels;
 public class SightingsQueryParameters
 {
     public int PageNumber { get; set; } = 1;
-    public int PageSize { get; set; } = 10;
-    public int? SpeciesId { get; set; } 
+    private int _pageSize = 10;
+    public int PageSize
+    {
+        get
+        { return _pageSize; }
+        set
+        { _pageSize = value < 50 ? _pageSize = value : _pageSize = _maxPageSize; }
+    }
+    private readonly int _maxPageSize = 50;
+    public int? SpeciesId { get; set; }
     public bool? HasImage { get; set; }
     public DateTime? SightingStartDate { get; set; }
     public DateTime? SightingEndDate { get; set; } = DateTime.UtcNow;

--- a/api/Models/ApiModels/SightingsQueryParameters.cs
+++ b/api/Models/ApiModels/SightingsQueryParameters.cs
@@ -4,4 +4,8 @@ public class SightingsQueryParameters
 {
     public int PageNumber { get; set; } = 1;
     public int PageSize { get; set; } = 10;
+    public int? SpeciesId { get; set; } 
+    public bool? HasImage { get; set; }
+    public DateTime? SightingStartDate { get; set; }
+    public DateTime? SightingEndDate { get; set; } = DateTime.UtcNow;
 }

--- a/api/Models/ApiModels/SightingsQueryParameters.cs
+++ b/api/Models/ApiModels/SightingsQueryParameters.cs
@@ -1,0 +1,7 @@
+namespace WhaleSpottingBackend.Models.ApiModels;
+
+public class SightingsQueryParameters
+{
+    public int PageNumber { get; set; } = 1;
+    public int PageSize { get; set; } = 10;
+}

--- a/api/Repositories/SightingRepository.cs
+++ b/api/Repositories/SightingRepository.cs
@@ -8,7 +8,7 @@ public interface ISightingRepository
 {
     Sighting GetSightingByID(int sightingId);
     Sighting CreateSighting(Sighting sighting);
-    IEnumerable<Sighting> GetAllSightings(SightingsQueryParameters parameters);
+    IEnumerable<Sighting> GetSightingsBySearchQuery(SightingsQueryParameters parameters);
 
 }
 
@@ -28,7 +28,7 @@ public class SightingRepository : ISightingRepository
             .FirstOrDefault();
     }
 
-    public IEnumerable<Sighting> GetAllSightings(SightingsQueryParameters parameters)
+    public IEnumerable<Sighting> GetSightingsBySearchQuery(SightingsQueryParameters parameters)
     {
         return _context.Sighting
             .Include(sighting => sighting.Location)

--- a/api/Repositories/SightingRepository.cs
+++ b/api/Repositories/SightingRepository.cs
@@ -33,6 +33,11 @@ public class SightingRepository : ISightingRepository
         return _context.Sighting
             .Include(sighting => sighting.Location)
             .Include(sighting => sighting.Species)
+            .Where(sighting => parameters.SpeciesId == null || sighting.SpeciesId == parameters.SpeciesId)
+            // .Where(sighting => parameters.HasImage == null || 
+            //     ((bool)parameters.HasImage ? sighting.ImageSource != null : sighting.ImageSource == null))
+            .Where(sighting => parameters.SightingStartDate == null ||
+                sighting.SightingDate >= parameters.SightingStartDate && sighting.SightingDate <= parameters.SightingEndDate)
             .Skip((parameters.PageNumber - 1) * parameters.PageSize)
             .Take(parameters.PageSize);
     }

--- a/api/Repositories/SightingRepository.cs
+++ b/api/Repositories/SightingRepository.cs
@@ -34,8 +34,8 @@ public class SightingRepository : ISightingRepository
             .Include(sighting => sighting.Location)
             .Include(sighting => sighting.Species)
             .Where(sighting => parameters.SpeciesId == null || sighting.SpeciesId == parameters.SpeciesId)
-            // .Where(sighting => parameters.HasImage == null || 
-            //     ((bool)parameters.HasImage ? sighting.ImageSource != null : sighting.ImageSource == null))
+            .Where(sighting => parameters.HasImage == null ||
+                ((bool)parameters.HasImage ? sighting.ImageSource != null : sighting.ImageSource == null))
             .Where(sighting => parameters.SightingStartDate == null ||
                 sighting.SightingDate >= parameters.SightingStartDate && sighting.SightingDate <= parameters.SightingEndDate)
             .Skip((parameters.PageNumber - 1) * parameters.PageSize)

--- a/api/Repositories/SightingRepository.cs
+++ b/api/Repositories/SightingRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using WhaleSpottingBackend.Database;
+using WhaleSpottingBackend.Models.ApiModels;
 using WhaleSpottingBackend.Models.DatabaseModels;
 namespace WhaleSpottingBackend.Repositories;
 
@@ -7,7 +8,7 @@ public interface ISightingRepository
 {
     Sighting GetSightingByID(int sightingId);
     Sighting CreateSighting(Sighting sighting);
-    IEnumerable<Sighting> GetAllSightings();
+    IEnumerable<Sighting> GetAllSightings(SightingsQueryParameters parameters);
 
 }
 
@@ -27,9 +28,13 @@ public class SightingRepository : ISightingRepository
             .FirstOrDefault();
     }
 
-    public IEnumerable<Sighting> GetAllSightings()
+    public IEnumerable<Sighting> GetAllSightings(SightingsQueryParameters parameters)
     {
-        return _context.Sighting.Include(sighting => sighting.Location).Include(sighting => sighting.Species);
+        return _context.Sighting
+            .Include(sighting => sighting.Location)
+            .Include(sighting => sighting.Species)
+            .Skip((parameters.PageNumber - 1) * parameters.PageSize)
+            .Take(parameters.PageSize);
     }
 
     public Sighting CreateSighting(Sighting sighting)


### PR DESCRIPTION
# Filtered and paginated sightings backend

## Issue ticket number and link
#25

## Describe your changes

Added query parameters to the GET /sightings endpoint to filter by:
- SpeciesId
- SightingStartDate and SightingEndDate
- HasImage 

Also added pagination:
- PageNumber 
- PageSize

## How Has This Been Tested?

Tested in Swagger using #30 Seed data

## Screenshots (if appropriate):
We included only part of the cases in the screenshots; otherwise, it would have taken up too much space.

![Get_sighting_endpoint](https://github.com/user-attachments/assets/df918b49-83d9-46b7-bdb0-201a34cb11ec)

When filter HasImage=false is applied, the result includes only sightings without images.

![Filter-HasImageFalse](https://github.com/user-attachments/assets/bfb6f355-b784-4d2a-be42-31c2f62d059a)

Filtering sightings from the given start date:

![Filter-ByStartDate](https://github.com/user-attachments/assets/d742b1a7-a21f-4a06-b196-6c78a67c9b87)
