### PR TITLE
#33 Populate species selector in create sighting form from backend

### DIFF
--- a/ui/src/components/formComponents/whaleSightingForm/WhaleSightingForm.tsx
+++ b/ui/src/components/formComponents/whaleSightingForm/WhaleSightingForm.tsx
@@ -36,21 +36,19 @@ export const WhaleSightingForm = () => {
   });
 
   const [dateValue, setDate] = useState<Value>(new Date());
-  const [errorMessage, setErrorMessage] = useState("");
+  const [formSubmissionError, setFormSubmissionError] = useState("");
   const [speciesOptions, setSpeciesOptions] = useState<Species[]>([]);
-  const [error, setError] = useState(false);
+  const [speciesLoadingError, setSpeciesLoadingError] = useState(false);
 
   useEffect(() => {
-    fetch(import.meta.env.VITE_APP_API_HOST + "/Species")
-      .then((response) => response.json())
-      .then((data) => {
-        setSpeciesOptions(data);
-        console.log(`Species data: ${data}`);
-      })
-      .catch((error) => {
-        setError(true);
-        console.log(error);
+    async function fetchSpecies() {
+      const species = await getAllSpecies().catch((error) => {
+        setSpeciesLoadingError(error);
       });
+
+      setSpeciesOptions(species);
+    }
+    fetchSpecies();
   }, []);
 
   const navigate = useNavigate();
@@ -66,12 +64,12 @@ export const WhaleSightingForm = () => {
         "/Sighting/createSighting",
       );
       if (response >= 300) {
-        setErrorMessage("An error has occurred.");
+        setFormSubmissionError("An error has occurred.");
       } else {
         navigate("/ViewSightings");
       }
     } catch {
-      setErrorMessage("An error has occurred.");
+      setFormSubmissionError("An error has occurred.");
     }
   };
 
@@ -90,17 +88,13 @@ export const WhaleSightingForm = () => {
     formData.sightingDate = dateValue;
   };
 
-  if (error) {
-    return <div>Error loading species from backend</div>;
-  }
-
   return (
     <div className="createSightingForm">
       <h2>Report your whale sighting</h2>
       <p>Tell us about the whale that you saw using the form below.</p>
       <p>* (asterisk) denotes a required field.</p>
-      {errorMessage.length > 0 && (
-        <p className="errorMessage">{errorMessage}</p>
+      {formSubmissionError.length > 0 && (
+        <p className="errorMessage">{formSubmissionError}</p>
       )}
       <form onSubmit={handleSubmit}>
         <div className="field">
@@ -144,13 +138,19 @@ export const WhaleSightingForm = () => {
             onChange={handleChange}
             required
           >
-            <option value="">Please select a species</option>
-            {speciesOptions &&
-              speciesOptions.map(({ id, speciesName }) => (
-                <option key={`speciesName-${id}`} value={id}>
-                  {speciesName}
-                </option>
-              ))}
+            {speciesLoadingError ? (
+              <div>Error loading species from backend</div>
+            ) : (
+              <>
+                <option value="">Please select a species</option>
+                {speciesOptions &&
+                  speciesOptions.map(({ id, speciesName }) => (
+                    <option key={`speciesName-${id}`} value={id}>
+                      {speciesName}
+                    </option>
+                  ))}
+              </>
+            )}
           </select>
         </div>
         <div className="field">

--- a/ui/src/components/formComponents/whaleSightingForm/WhaleSightingForm.tsx
+++ b/ui/src/components/formComponents/whaleSightingForm/WhaleSightingForm.tsx
@@ -64,12 +64,16 @@ export const WhaleSightingForm = () => {
         "/Sighting/createSighting",
       );
       if (response >= 300) {
-        setFormSubmissionError("An error has occurred.");
+        setFormSubmissionError(
+          "An error has occurred with the form. Please contact the administrator.",
+        );
       } else {
         navigate("/ViewSightings");
       }
     } catch {
-      setFormSubmissionError("An error has occurred.");
+      setFormSubmissionError(
+        "An error has occurred with the form. Please contact the administrator.",
+      );
     }
   };
 
@@ -139,7 +143,7 @@ export const WhaleSightingForm = () => {
             required
           >
             {speciesLoadingError ? (
-              <div>Error loading species from backend</div>
+              <div>Error loading species</div>
             ) : (
               <>
                 <option value="">Please select a species</option>

--- a/ui/src/components/formComponents/whaleSightingForm/WhaleSightingForm.tsx
+++ b/ui/src/components/formComponents/whaleSightingForm/WhaleSightingForm.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Calendar from "react-calendar";
 import "react-calendar/dist/Calendar.css";
 import "./WhaleSightingForm.scss";
-import { fetchPOSTRequest } from "../../../utils/apiClient";
+import { fetchPOSTRequest, getAllSpecies } from "../../../utils/apiClient";
 import { useNavigate } from "react-router-dom";
 
 type ValuePiece = Date | null;
@@ -19,6 +19,11 @@ export interface WhaleSighting {
   imageSource: string;
 }
 
+interface Species {
+  id: number;
+  speciesName: string;
+}
+
 export const WhaleSightingForm = () => {
   const [formData, setFormData] = useState<WhaleSighting>({
     species: 0,
@@ -32,6 +37,21 @@ export const WhaleSightingForm = () => {
 
   const [dateValue, setDate] = useState<Value>(new Date());
   const [errorMessage, setErrorMessage] = useState("");
+  const [speciesOptions, setSpeciesOptions] = useState<Species[]>([]);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    fetch(import.meta.env.VITE_APP_API_HOST + "/Species")
+      .then((response) => response.json())
+      .then((data) => {
+        setSpeciesOptions(data);
+        console.log(`Species data: ${data}`);
+      })
+      .catch((error) => {
+        setError(true);
+        console.log(error);
+      });
+  }, []);
 
   const navigate = useNavigate();
 
@@ -69,6 +89,10 @@ export const WhaleSightingForm = () => {
     setDate(dateValue);
     formData.sightingDate = dateValue;
   };
+
+  if (error) {
+    return <div>Error loading species from backend</div>;
+  }
 
   return (
     <div className="createSightingForm">
@@ -121,17 +145,12 @@ export const WhaleSightingForm = () => {
             required
           >
             <option value="">Please select a species</option>
-            <option value="1">Blue Whale</option>
-            <option value="2">Humpback Whale</option>
-            <option value="3">Sperm Whale</option>
-            <option value="4">Orca</option>
-            <option value="5">Fin Whale</option>
-            <option value="6">Minke Whale</option>
-            <option value="7">Beluga Whale</option>
-            <option value="8">Gray Whale</option>
-            <option value="9">Right Whale</option>
-            <option value="10">Bowhead Whale</option>
-            <option value="11">Unknown</option>
+            {speciesOptions &&
+              speciesOptions.map(({ id, speciesName }) => (
+                <option key={`speciesName-${id}`} value={id}>
+                  {speciesName}
+                </option>
+              ))}
           </select>
         </div>
         <div className="field">

--- a/ui/src/utils/apiClient.tsx
+++ b/ui/src/utils/apiClient.tsx
@@ -25,7 +25,7 @@ export const getSightings = async () => {
 
 export const getAllSpecies = async () => {
   const fetchResponse = await fetch(
-    import.meta.env.VITE_APP_API_HOST + "Species/",
+    import.meta.env.VITE_APP_API_HOST + "/Species/",
   );
   const data = await fetchResponse.json();
   return data;

--- a/ui/src/utils/apiClient.tsx
+++ b/ui/src/utils/apiClient.tsx
@@ -22,3 +22,11 @@ export const getSightings = async () => {
   const data = await fetchResponse.json();
   return data;
 };
+
+export const getAllSpecies = async () => {
+  const fetchResponse = await fetch(
+    import.meta.env.VITE_APP_API_HOST + "Species/",
+  );
+  const data = await fetchResponse.json();
+  return data;
+};


### PR DESCRIPTION
## Issue ticket number and link
#33 

## Describe your changes

Added fetch request to API Client.
Added error handling.
Populated the species dropdown on the sighting form from the backend /Species endpoint.

## How Has This Been Tested?

Visually checked that the form was populated with the species.
Filled in the form and checked the response.

## Screenshots (if appropriate):

![{5E2D41AE-B883-4BF9-824D-33ED816E789F}](https://github.com/user-attachments/assets/f9d54db9-cbef-4660-bb32-5169a5b4b6b4)

