### PR TITLE
#45 create admin page

### DIFF
--- a/api/Controllers/ReviewController.cs
+++ b/api/Controllers/ReviewController.cs
@@ -47,7 +47,7 @@ public class ReviewController : ControllerBase
         {
             Sighting sighting = _sightingRepository.GetSightingByID(reviewRequest.SightingId);
             sighting.Description = reviewRequest.UpdatedSighting.Description ?? sighting.Description;
-            sighting.Species = reviewRequest.UpdatedSighting.Species ?? sighting.Species;
+            sighting.SpeciesId = reviewRequest.UpdatedSighting.Species.Id;
             _sightingRepository.UpdateSighting(sighting);
         }
         return Ok("Review completed successfully.");

--- a/api/Repositories/SightingRepository.cs
+++ b/api/Repositories/SightingRepository.cs
@@ -113,8 +113,8 @@ public class SightingRepository : ISightingRepository
     {
         return _context.Sighting
             .Include(sighting => sighting.Reviews)
+            .Include(sighting => sighting.Species)
             .Where(sighting => !sighting.Reviews.Any())
             .OrderBy(sighting => sighting.SightingDate);
-
     }
 }

--- a/ui/src/components/pages/Admin/Admin.scss
+++ b/ui/src/components/pages/Admin/Admin.scss
@@ -1,42 +1,11 @@
 @use '@/styles/constants';
 
 .admin {
-    &__info {
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        padding: 16px;
-    }
-
-    &__details {
-        display: flex;
-    }
-
-    &__password {
-        position: relative;
-        padding-right: 8px;
-
-        &::after {
-            position: absolute;
-            content: '';
-
-            right: 0;
-            top: 0;
-            bottom: 0;
-            width: 2px;
-            background-color: black;
-        }
-    }
-
-    &__email {
-        padding-left: 8px;
-    }
-
     &__approvals-title {
         display: flex;
         flex-direction: column;
         align-items: flex-start;
-        padding: 16px;
+        padding: constants.$padding-default;
     }
 
     &__approve {
@@ -45,5 +14,10 @@
 
     &__reject {
         @include constants.button-deny;
+    }
+
+    &__error{
+        width: 100%;
+        color: constants.$text-error;
     }
 }

--- a/ui/src/components/pages/Admin/Admin.scss
+++ b/ui/src/components/pages/Admin/Admin.scss
@@ -1,0 +1,49 @@
+@use '@/styles/constants';
+
+.admin {
+    &__info {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        padding: 16px;
+    }
+
+    &__details {
+        display: flex;
+    }
+
+    &__password {
+        position: relative;
+        padding-right: 8px;
+
+        &::after {
+            position: absolute;
+            content: '';
+
+            right: 0;
+            top: 0;
+            bottom: 0;
+            width: 2px;
+            background-color: black;
+        }
+    }
+
+    &__email {
+        padding-left: 8px;
+    }
+
+    &__approvals-title {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        padding: 16px;
+    }
+
+    &__approve {
+        @include constants.button-approve;
+    }
+
+    &__reject {
+        @include constants.button-deny;
+    }
+}

--- a/ui/src/components/pages/Admin/Admin.tsx
+++ b/ui/src/components/pages/Admin/Admin.tsx
@@ -3,7 +3,7 @@ import { LoginContext } from "../../LoginManager/LoginManager";
 import { useEffect, useState } from "react";
 import {
   CreateReviewRequest,
-  SightingsResponse,
+  PendingApprovalModel,
   Species,
 } from "../../../models/apiModels";
 import "./Admin.scss";
@@ -16,9 +16,9 @@ import { PendingApproval } from "../../pendingApproval/PendingApproval";
 
 export const Admin = () => {
   const loginContext = useContext(LoginContext);
-  const [pendingApprovals, setPendingApprovals] = useState<SightingsResponse[]>(
-    [],
-  );
+  const [pendingApprovals, setPendingApprovals] = useState<
+    PendingApprovalModel[]
+  >([]);
   const [speciesOptions, setSpeciesOptions] = useState<Species[]>([]);
   const [pendingApprovalsError, setPendingApprovalsError] = useState("");
   const [speciesLoadingError, setSpeciesLoadingError] = useState("");

--- a/ui/src/components/pages/Admin/Admin.tsx
+++ b/ui/src/components/pages/Admin/Admin.tsx
@@ -1,8 +1,62 @@
 import { useContext } from "react";
 import { LoginContext } from "../../LoginManager/LoginManager";
+import { useEffect, useState } from "react";
+import { SightingsResponse, Species } from "../../../models/apiModels";
+import "./Admin.scss";
+import { getAllSpecies, getPendingApprovalS } from "../../../utils/apiClient";
+
+const testPendindApprovals = [
+  {
+    id: 9,
+    species: {
+      id: 9,
+      speciesName: "Right Whale",
+    },
+    description: "Details of Sighting 9",
+    sightingDate: "2024-03-09T13:21:33Z",
+    reportDate: "2024-03-10T13:21:33Z",
+    quantity: 1,
+    location: {
+      id: 9,
+      latitude: 44.420668,
+      longitude: -56.366203,
+    },
+    imageSource: "http://localhost:5067/images/blue-whale.jpg",
+  },
+];
 
 export const Admin = () => {
   const loginContext = useContext(LoginContext);
+  const [pendingApprovals, setPendingApprovals] = useState<SightingsResponse[]>(
+    [],
+  );
+  const [pendingApprovalsError, setPendingApprovalsError] = useState(false);
+  const [speciesOptions, setSpeciesOptions] = useState<Species[]>([]);
+  const [speciesLoadingError, setSpeciesLoadingError] = useState(false);
+  const [selectedSpecies, setSelectedSpecies] = useState<Species | null>(null);
+
+  useEffect(() => {
+    async function fetchPendingApprovals() {
+      // const pendingApprovals = await getPendingApprovalS().catch((error) => {
+      //   setPendingApprovalsError(error);
+      // });
+      // setPendingApprovals(pendingApprovals);
+      setPendingApprovals(testPendindApprovals);
+    }
+    fetchPendingApprovals();
+  }, []);
+
+  useEffect(() => {
+    async function fetchSpecies() {
+      const species = await getAllSpecies().catch((error) => {
+        setSpeciesLoadingError(error);
+      });
+
+      setSpeciesOptions(species);
+    }
+    fetchSpecies();
+  }, []);
+
   if (!loginContext.isLoggedIn && !loginContext.isAdmin) {
     return (
       <div>
@@ -13,4 +67,106 @@ export const Admin = () => {
       </div>
     );
   }
+
+  // This part is hardcoded because it hasn't been implemented.
+  const renderAdminInfo = () => (
+    <div className="admin__info">
+      <h2>Hello Whale_spotting!</h2>
+      <div>Role: Admin</div>
+      <div className="admin__details">
+        <div className="admin__password">Edit: Password</div>
+        <div className="admin__email">Edit: Email</div>
+      </div>
+    </div>
+  );
+
+  const renderPendingApprovalsTitle = () => {
+    const pendingApprovalsCount = pendingApprovals.length;
+
+    return (
+      <div className="admin__approvals-title">
+        <h2>Pending Approvals</h2>
+        {pendingApprovalsCount >= 1 ? (
+          <div>
+            You have {pendingApprovalsCount} sighting
+            {pendingApprovalsCount !== 1 && "s"} to approve!
+          </div>
+        ) : (
+          <div>You have no sightings to approve</div>
+        )}
+      </div>
+    );
+  };
+
+  const renderSpeciesOptions = (sighting: SightingsResponse) => (
+    <select
+      className="inputStyle"
+      name="species"
+      value={sighting.species.speciesName}
+      // onChange={handleChangeSpecies}
+      required
+    >
+      {speciesLoadingError ? (
+        <div>Error loading species</div>
+      ) : (
+        <>
+          <option value="">Change species</option>
+          {speciesOptions &&
+            speciesOptions.map(({ id, speciesName }) => (
+              <option key={`admin-page-speciesName-${id}`} value={id}>
+                {speciesName}
+              </option>
+            ))}
+        </>
+      )}
+    </select>
+  );
+
+  const renderPendingAppovalsTableHeader = () => (
+    <thead className="table-header">
+      <th className="table-cell">Id</th>
+      <th className="table-cell">Species</th>
+      <th className="table-cell">Description</th>
+      <th className="table-cell">Approve</th>
+      <th className="table-cell">Reject</th>
+    </thead>
+  );
+
+  const renderPendingApprovalsTableBody = () => (
+    <tbody>
+      {pendingApprovals?.map((sighting) => (
+        <tr className="table-row">
+          <td className="table-cell">{sighting.id}</td>
+          <td className="table-cell">
+            <div>{sighting.species.speciesName}</div>
+            <div>{renderSpeciesOptions(sighting)}</div>
+          </td>
+          <td className="table-cell">{sighting.description}</td>
+          <td className="table-cell">
+            <button className="admin__approve">Approve</button>
+          </td>
+          <td className="table-cell">
+            <button className="admin__reject">Deny</button>
+          </td>
+        </tr>
+      ))}
+    </tbody>
+  );
+
+  const renderPendingApprovalsTable = () => {
+    return (
+      <table id="" className="table-container">
+        {renderPendingAppovalsTableHeader()}
+        {renderPendingApprovalsTableBody()}
+      </table>
+    );
+  };
+
+  return (
+    <div>
+      {renderAdminInfo()}
+      {renderPendingApprovalsTitle()}
+      {pendingApprovals.length > 0 && renderPendingApprovalsTable()}
+    </div>
+  );
 };

--- a/ui/src/components/pages/ViewSightings/ViewSightings.scss
+++ b/ui/src/components/pages/ViewSightings/ViewSightings.scss
@@ -30,7 +30,6 @@ table {
     justify-content: space-between;
     padding: constants.$padding-small constants.$padding-large;
     border-bottom: 1px solid #ddd;
-    align-items: center;
 }
  
 .table-header {

--- a/ui/src/components/pages/ViewSightings/ViewSightings.scss
+++ b/ui/src/components/pages/ViewSightings/ViewSightings.scss
@@ -1,2 +1,91 @@
 @use "sass:color";
 @use '@/styles/constants';
+
+// Desktop styling
+img{
+    width: 50%;
+    height: auto;
+}
+
+table {
+    width: 100%;
+    border: 1px solid;
+}
+
+.table-container {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    margin: 40px auto;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    background-color: #fff;
+    border-radius: constants.$border-radius;
+    font-size: constants.$font-size-normal;
+    font-family: constants.$font-family-normal;
+    overflow: hidden;
+}
+ 
+.table-header, .table-row {
+    display: flex;
+    justify-content: space-between;
+    padding: constants.$padding-small constants.$padding-large;
+    border-bottom: 1px solid #ddd;
+    align-items: center;
+}
+ 
+.table-header {
+    background-color: #5d626f;
+    color: #fff;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+ 
+.table-row:nth-child(even) {
+    background-color: #f9f9f9;
+}
+ 
+.table-row:hover {
+    background-color: #d6e9f5;
+}
+.table-cell {
+    flex: 1;
+    text-align: left;
+}
+ 
+.table-cell.status {
+    flex: 1;
+    text-align: center;
+}
+
+// Mobile styling
+@media (max-width: constants.$tablet-min-width) {
+    .ul-container {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        margin: 40px auto;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+        background-color: #fff;
+        border-radius: constants.$border-radius;
+        overflow: hidden;
+        margin-right: auto;
+        padding: constants.$padding-default;
+        gap: 10px;
+    }
+    
+    .li-item {
+        list-style-type: none;
+        border-radius: constants.$border-radius;;
+        border: 2px solid constants.$background-navigation;;
+        align-content: flex-start;
+        padding: constants.$padding-default;
+        font-size: constants.$font-size-normal;
+        font-family: constants.$font-family-normal;
+    }
+    
+    img {
+        width: 90%;
+        height: auto;
+        border-radius: constants.$border-radius;
+    }   
+}

--- a/ui/src/components/pendingApproval/PendingApproval.scss
+++ b/ui/src/components/pendingApproval/PendingApproval.scss
@@ -1,0 +1,29 @@
+@use '@/styles/constants';
+
+.pending-approval{
+    display: flex;
+    flex-direction: row;
+    justify-content: left;  
+    align-items: center;  
+    flex-wrap: wrap;
+
+    &__item {
+        flex: 1 1 100px; 
+        box-sizing: border-box;
+        padding: constants.$padding-small;
+    }      
+
+    & textarea {
+        display: block;
+    }
+}
+
+.pending-approval__species {
+    padding: constants.$padding-small;
+    border-radius: 8px;
+}
+
+.edit-button {
+    background: transparent;
+    font-size: 28px;
+}

--- a/ui/src/components/pendingApproval/PendingApproval.tsx
+++ b/ui/src/components/pendingApproval/PendingApproval.tsx
@@ -1,14 +1,14 @@
 import { ChangeEvent, useState } from "react";
 import {
   CreateReviewRequest,
-  SightingsResponse,
+  PendingApprovalModel,
   Species,
   UpdateSightingRequest,
 } from "../../models/apiModels";
 import "./PendingApproval.scss";
 
 interface PendingApprovalProps {
-  sighting: SightingsResponse;
+  sighting: PendingApprovalModel;
   speciesOptions: Species[];
   onPostReview: (request: CreateReviewRequest) => void;
 }

--- a/ui/src/components/pendingApproval/PendingApproval.tsx
+++ b/ui/src/components/pendingApproval/PendingApproval.tsx
@@ -1,0 +1,140 @@
+import { ChangeEvent, useState } from "react";
+import {
+  CreateReviewRequest,
+  SightingsResponse,
+  Species,
+  UpdateSightingRequest,
+} from "../../models/apiModels";
+import "./PendingApproval.scss";
+
+interface PendingApprovalProps {
+  sighting: SightingsResponse;
+  speciesOptions: Species[];
+  onPostReview: (request: CreateReviewRequest) => void;
+}
+
+export const PendingApproval = (props: PendingApprovalProps) => {
+  const { sighting, speciesOptions, onPostReview } = props;
+
+  const [isEditable, setIsEditable] = useState<boolean>(false);
+  const [description, setDescription] = useState<string>(sighting.description);
+  const [selectedSpecies, setSelectedSpecies] = useState<Species>(
+    // { id: sighting.speciesId, speciesName: sighting.speciesName }, // TODO Use this for sightingresponsmodel
+    // after #16 is merged to main
+    sighting.species,
+  );
+  const [comments, setComments] = useState<string>("");
+
+  const handleApprove = (sightingId: number, approved: boolean) => {
+    const request: CreateReviewRequest = {
+      sightingId,
+      approved,
+      comments,
+    };
+
+    if (isEditable) {
+      const updateSighting: UpdateSightingRequest = {
+        species: selectedSpecies,
+        description,
+      };
+      request.updatedSighting = updateSighting;
+    }
+    onPostReview(request);
+  };
+
+  const handleEdit = () => {
+    if (isEditable) {
+      setDescription(sighting.description);
+      // const species: Species = { id: sighting.speciesId, speciesName: sighting.speciesName }
+      // setSelectedSpecies(species); // TODO use this after #16 is merged to main
+      setSelectedSpecies(sighting.species);
+    }
+    setIsEditable(!isEditable);
+  };
+
+  const handleDescriptionChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setDescription(event.target.value);
+  };
+
+  const handleChangeSpecies = (event: ChangeEvent<HTMLSelectElement>) => {
+    const species: Species = {
+      id: Number(event.target.value),
+      speciesName: event.target.options[event.target.selectedIndex].text,
+    };
+    setSelectedSpecies(species);
+  };
+
+  const handleCommentsChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setComments(event.target.value);
+  };
+
+  const renderSpeciesOptions = () => (
+    <select
+      className="pending-approval__species"
+      name="species"
+      value={selectedSpecies.id}
+      onChange={handleChangeSpecies}
+      required
+    >
+      {speciesOptions.map(({ id, speciesName }) => (
+        <option key={`admin-page-speciesName-${id}`} value={id}>
+          {speciesName}
+        </option>
+      ))}
+    </select>
+  );
+
+  return (
+    <div className="pending-approval">
+      <div className="pending-approval__item">{sighting.id}</div>
+      <div className="pending-approval__item">
+        {isEditable ? (
+          <div>{renderSpeciesOptions()}</div>
+        ) : (
+          <div>{selectedSpecies.speciesName}</div>
+        )}
+      </div>
+      <div className="pending-approval__item">
+        {isEditable ? (
+          <textarea
+            id="description"
+            onChange={handleDescriptionChange}
+            value={description}
+          ></textarea>
+        ) : (
+          <label>{description}</label>
+        )}
+      </div>
+      <div className="pending-approval__item">
+        <button onClick={handleEdit} className="edit-button">
+          {isEditable ? "↩️" : "✏️"}
+        </button>
+      </div>
+      <div className="pending-approval__item">
+        <textarea
+          id="comments"
+          name="comments"
+          value={comments}
+          placeholder="Comments"
+          onChange={handleCommentsChange}
+        ></textarea>
+      </div>
+      <div className="pending-approval__item">
+        <button
+          onClick={() => handleApprove(sighting.id, true)}
+          className="admin__approve"
+        >
+          Approve
+        </button>
+      </div>
+      <div className="pending-approval__item">
+        <button
+          onClick={() => handleApprove(sighting.id, false)}
+          className="admin__reject"
+        >
+          Deny
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/ui/src/components/pendingApproval/PendingApproval.tsx
+++ b/ui/src/components/pendingApproval/PendingApproval.tsx
@@ -18,7 +18,9 @@ export const PendingApproval = (props: PendingApprovalProps) => {
 
   const [isEditable, setIsEditable] = useState<boolean>(false);
   const [description, setDescription] = useState<string>(sighting.description);
-  const [selectedSpecies, setSelectedSpecies] = useState<Species>(sighting.species);
+  const [selectedSpecies, setSelectedSpecies] = useState<Species>(
+    sighting.species,
+  );
   const [comments, setComments] = useState<string>("");
 
   const handleApprove = (sightingId: number, approved: boolean) => {

--- a/ui/src/components/pendingApproval/PendingApproval.tsx
+++ b/ui/src/components/pendingApproval/PendingApproval.tsx
@@ -18,11 +18,7 @@ export const PendingApproval = (props: PendingApprovalProps) => {
 
   const [isEditable, setIsEditable] = useState<boolean>(false);
   const [description, setDescription] = useState<string>(sighting.description);
-  const [selectedSpecies, setSelectedSpecies] = useState<Species>(
-    // { id: sighting.speciesId, speciesName: sighting.speciesName }, // TODO Use this for sightingresponsmodel
-    // after #16 is merged to main
-    sighting.species,
-  );
+  const [selectedSpecies, setSelectedSpecies] = useState<Species>(sighting.species);
   const [comments, setComments] = useState<string>("");
 
   const handleApprove = (sightingId: number, approved: boolean) => {
@@ -45,8 +41,6 @@ export const PendingApproval = (props: PendingApprovalProps) => {
   const handleEdit = () => {
     if (isEditable) {
       setDescription(sighting.description);
-      // const species: Species = { id: sighting.speciesId, speciesName: sighting.speciesName }
-      // setSelectedSpecies(species); // TODO use this after #16 is merged to main
       setSelectedSpecies(sighting.species);
     }
     setIsEditable(!isEditable);

--- a/ui/src/models/apiModels.ts
+++ b/ui/src/models/apiModels.ts
@@ -46,3 +46,14 @@ export interface FilterSightings {
   Longitude: number;
   Radius: number;
 }
+export interface CreateReviewRequest {
+  sightingId: number;
+  approved: boolean;
+  comments: string;
+  updatedSighting?: UpdateSightingRequest;
+}
+
+export interface UpdateSightingRequest {
+  species: Species;
+  description: string;
+}

--- a/ui/src/models/apiModels.ts
+++ b/ui/src/models/apiModels.ts
@@ -18,6 +18,18 @@ export interface SightingsResponse {
   ];
 }
 
+export interface PendingApprovalModel {
+  id: number;
+  species: Species;
+  description: string;
+  sightingDate: string;
+  reportDate: string;
+  quantity: number;
+  latitude: number;
+  longitude: number;
+  imageSource: string;
+}
+
 export interface Species {
   id: number;
   speciesName: string;

--- a/ui/src/styles/constants.scss
+++ b/ui/src/styles/constants.scss
@@ -32,6 +32,7 @@ $background-color-deny: #e62143;
 
 @mixin button($color) {
     background-color: $color;
+    cursor: pointer;
 }
 
 @mixin button-approve {

--- a/ui/src/utils/apiClient.tsx
+++ b/ui/src/utils/apiClient.tsx
@@ -1,5 +1,5 @@
-import { Login, Registration } from "../models/apiModels";
 import { FilterSightings } from "../models/apiModels";
+import { Login, Registration, CreateReviewRequest } from "../models/apiModels";
 
 export const fetchPOSTRequest = async (
   formData: FormData,
@@ -28,6 +28,11 @@ export const getAllSpecies = async () => {
   const fetchResponse = await fetch(
     import.meta.env.VITE_APP_API_HOST + "/Species/",
   );
+
+  if (!fetchResponse.ok) {
+    throw new Error(`An error has occurred while loading species. 
+      Status: ${fetchResponse.status}`);
+  }
   const data = await fetchResponse.json();
   return data;
 };
@@ -120,10 +125,32 @@ export const register = async (formData: Registration) => {
   return fetchResponse;
 };
 
-export const getPendingApprovalS = async () => {
+export const getPendingApprovals = async () => {
   const fetchResponse = await fetch(
     import.meta.env.VITE_APP_API_HOST + "/sighting/pending-approval/",
+    {
+      method: "GET",
+      credentials: "include",
+    },
   );
+
+  if (!fetchResponse.ok) {
+    throw new Error(`An error has occurred while loading pending approvals. 
+      Status: ${fetchResponse.status}`);
+  }
   const data = await fetchResponse.json();
   return data;
+};
+
+export const postReview = async (reviewRequest: CreateReviewRequest) => {
+  const fetchResponse = await fetch(
+    import.meta.env.VITE_APP_API_HOST + "/review/update-status",
+    {
+      method: "POST",
+      body: JSON.stringify(reviewRequest),
+      headers: new Headers({ "Content-Type": "application/json" }),
+      credentials: "include",
+    },
+  );
+  return fetchResponse.status;
 };

--- a/ui/src/utils/apiClient.tsx
+++ b/ui/src/utils/apiClient.tsx
@@ -119,3 +119,11 @@ export const register = async (formData: Registration) => {
   );
   return fetchResponse;
 };
+
+export const getPendingApprovalS = async () => {
+  const fetchResponse = await fetch(
+    import.meta.env.VITE_APP_API_HOST + "/sighting/pending-approval/",
+  );
+  const data = await fetchResponse.json();
+  return data;
+};


### PR DESCRIPTION
# Title
Create an admin page.

## Issue ticket number and link
#45
## Describe your changes

- Built an admin page that allows admins to approve or deny sightings.
- Provided an option for admins to update the species, description and add comments before approving or denying a sighting.
- After an admin approves or denies a sighting, it should be removed from the pending approvals page.
- Implemented error handling and applied styling.

## How Has This Been Tested?

- Confirmed admin approve/deny actions via database verification and view sightings page.
- Verified that admin can edit sighting's species and description.
- Verified that admin can add comments before approving/denying any sighting.
- Verified error handling by manually introducing  errors in the code.


## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/b58d897e-434d-4919-a2e6-ea90afe96c9e)
![image](https://github.com/user-attachments/assets/49b3922f-a61f-451d-b092-647aeccb4b71)
![image](https://github.com/user-attachments/assets/b96e0c5c-ca9a-4210-8c0d-05eaf5f2bd63)
